### PR TITLE
Fix for issue #2 about chunk method signature. IMPORTANT: this break c…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
     "symfony/uid": "^5.1|^6.3|^7"
   },
   "require": {
-    "php": "^8.1",
-    "illuminate/collections": "^10|^11|^12"
+    "php": "^8.2",
+    "illuminate/collections": "^12"
   },
   "require-dev": {
     "calebporzio/sushi": "^2.4",
-    "orchestra/testbench": "^8|^9|^10",
+    "orchestra/testbench": "^10.0",
     "phpstan/phpstan": "^1.4",
-    "phpunit/phpunit": "^9.6.6|^10",
+    "phpunit/phpunit": "^11.5.3",
     "ramsey/uuid": "^4.2.2",
     "symfony/uid": "^5.1|^6.3|^7"
   },

--- a/src/Concerns/OverridesMethods.php
+++ b/src/Concerns/OverridesMethods.php
@@ -103,10 +103,10 @@ trait OverridesMethods
         return new $lazyClass($this->all());
     }
 
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         return $this->collect()
-            ->chunk($size)
+            ->chunk($size, $preserveKeys)
             ->mapInto(static::class);
     }
 

--- a/src/LazyTypedCollection.php
+++ b/src/LazyTypedCollection.php
@@ -84,11 +84,11 @@ abstract class LazyTypedCollection extends LazyCollection
             ->mapInto(static::class);
     }
 
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         return (new LazyCollection(
             $this
-        ))->chunk($size)
+        ))->chunk($size, $preserveKeys)
             ->mapInto(static::class);
     }
 

--- a/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
@@ -37,13 +37,13 @@ class InvalidTypeExceptionTest extends TestCase
     public static function providesTypeTestcases()
     {
         return [
-            'string' => ['item' => 'Hello World', 'string'],
-            'numeric' => ['item' => '21', 'numeric'],
-            'resource' => ['item' => STDIN, 'resource'],
-            'double' => ['item' => 1.1, 'double'],
-            'array' => ['item' => ['hello'], 'array'],
-            'boolean' => ['item' => true, 'boolean'],
-            'integer' => ['item' => 21, 'integer'],
+            'string' => ['item' => 'Hello World', 'expectedValue' => 'string'],
+            'numeric' => ['item' => '21', 'expectedValue' => 'numeric'],
+            'resource' => ['item' => STDIN, 'expectedValue' => 'resource'],
+            'double' => ['item' => 1.1, 'expectedValue' => 'double'],
+            'array' => ['item' => ['hello'], 'expectedValue' => 'array'],
+            'boolean' => ['item' => true, 'expectedValue' => 'boolean'],
+            'integer' => ['item' => 21, 'expectedValue' => 'integer'],
         ];
     }
 

--- a/tests/Unit/TypedCollectionTest.php
+++ b/tests/Unit/TypedCollectionTest.php
@@ -730,4 +730,36 @@ class TypedCollectionTest extends TestCase
 
         $this->assertCount(3, $collection);
     }
+
+    public function testChunkReturnsNewCollectionWithoutKeys()
+    {
+        $fruits = new class(['first' => 'apple', 'second' => 'banana', 'third' => 'cherry']) extends TypedCollection {
+            protected function generics(): string|Type|array
+            {
+                return Type::String;
+            }
+        };
+
+        $chunks = $fruits->chunk(2, false);
+
+        $firstChunk = $chunks->first();
+        $this->assertInstanceOf($fruits::class, $firstChunk);
+        $this->assertSame(0, $firstChunk->keys()->first());
+    }
+
+    public function testChunkReturnsNewCollectionWithKeys()
+    {
+        $fruits = new class(['first' => 'apple', 'second' => 'banana', 'third' => 'cherry']) extends TypedCollection {
+            protected function generics(): string|Type|array
+            {
+                return Type::String;
+            }
+        };
+
+        $chunks = $fruits->chunk(2);
+
+        $firstChunk = $chunks->first();
+        $this->assertInstanceOf($fruits::class, $firstChunk);
+        $this->assertSame('first', $firstChunk->keys()->first());
+    }
 }


### PR DESCRIPTION
Fix for issue #2 about chunk method signature. 

IMPORTANT: this breaks compatibility with Laravel versions previous to 12 because it changes the signature of the chunk method. Also I  fixed an issue in another test about named arguments.