### PR TITLE
fixes chunk compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "calebporzio/sushi": "^2.4",
     "orchestra/testbench": "^8|^9|^10",
     "phpstan/phpstan": "^1.4",
-    "phpunit/phpunit": "^9.6.6|^10",
+    "phpunit/phpunit": "^9.6.6|^10|^11",
     "ramsey/uuid": "^4.2.2",
     "symfony/uid": "^5.1|^6.3|^7"
   },

--- a/src/Concerns/OverridesMethods.php
+++ b/src/Concerns/OverridesMethods.php
@@ -103,10 +103,10 @@ trait OverridesMethods
         return new $lazyClass($this->all());
     }
 
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         return $this->collect()
-            ->chunk($size)
+            ->chunk($size, $preserveKeys)
             ->mapInto(static::class);
     }
 

--- a/src/LazyTypedCollection.php
+++ b/src/LazyTypedCollection.php
@@ -84,11 +84,11 @@ abstract class LazyTypedCollection extends LazyCollection
             ->mapInto(static::class);
     }
 
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         return (new LazyCollection(
             $this
-        ))->chunk($size)
+        ))->chunk($size, $preserveKeys)
             ->mapInto(static::class);
     }
 

--- a/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
@@ -37,13 +37,13 @@ class InvalidTypeExceptionTest extends TestCase
     public static function providesTypeTestcases()
     {
         return [
-            'string' => ['item' => 'Hello World', 'string'],
-            'numeric' => ['item' => '21', 'numeric'],
-            'resource' => ['item' => STDIN, 'resource'],
-            'double' => ['item' => 1.1, 'double'],
-            'array' => ['item' => ['hello'], 'array'],
-            'boolean' => ['item' => true, 'boolean'],
-            'integer' => ['item' => 21, 'integer'],
+            'string' => ['Hello World', 'string'],
+            'numeric' => ['21', 'numeric'],
+            'resource' => [STDIN, 'resource'],
+            'double' => [1.1, 'double'],
+            'array' => [['hello'], 'array'],
+            'boolean' => [true, 'boolean'],
+            'integer' => [21, 'integer'],
         ];
     }
 

--- a/tests/Unit/TypedCollectionTest.php
+++ b/tests/Unit/TypedCollectionTest.php
@@ -579,6 +579,32 @@ class TypedCollectionTest extends TestCase
         $this->assertSame([2 => '!'], $chunks->last()->all());
     }
 
+    public function testChunkPreserveKeys(): void
+    {
+        $version = app()->version();
+        if (version_compare($version, '12.0', '<')) {
+            $this->markTestSkipped('This test requires Laravel 12 or higher');
+        }
+
+        $collection = new class([1 => 'hello', 3 => 'world', 5 => '!']) extends TypedCollection {
+            protected function generics(): Type
+            {
+                return Type::String;
+            }
+        };
+
+        $chunks = $collection->chunk(2, true);
+
+        $this->assertCount(2, $chunks);
+
+        foreach ($chunks as $chunk) {
+            $this->assertInstanceOf($collection::class, $chunk);
+        }
+
+        $this->assertSame([1 => 'hello', 3 => 'world'], $chunks->first()->all());
+        $this->assertSame([5 => '!'], $chunks->last()->all());
+    }
+
     public function testAllowMapping()
     {
         $this->assertEquals(


### PR DESCRIPTION
## Summary
  • Adds optional `$preserveKeys` parameter to chunk methods in TypedCollection and LazyTypedCollection for Laravel 12 compatibility
  • Updates PHPUnit dependency to support version 11

fixes: #2 