### PR TITLE
conversion of tests to pest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --quiet
 
       - name: Execute PHPUnit
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        run: vendor/bin/pest --coverage-clover=coverage.xml
 
       - name: Upload coverage to codeclimate
         uses: paambaati/codeclimate-action@v3.1.1

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
   "require-dev": {
     "calebporzio/sushi": "^2.4",
     "orchestra/testbench": "^8|^9|^10",
+    "pestphp/pest": "^2.0",
     "phpstan/phpstan": "^1.4",
     "phpunit/phpunit": "^9.6.6|^10|^11",
     "ramsey/uuid": "^4.2.2",
@@ -53,16 +54,17 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit",
-    "test-coverage-txt": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text",
-    "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html coverage",
-    "test-dox": "vendor/bin/phpunit --testdox",
+    "test": "vendor/bin/pest",
+    "test-coverage-txt": "XDEBUG_MODE=coverage vendor/bin/pest --coverage-text",
+    "test-coverage": "XDEBUG_MODE=coverage vendor/bin/pest --coverage-html coverage",
+    "test-dox": "vendor/bin/pest --testdox",
     "infection": "vendor/bin/infection --git-diff-filter=AM"
   },
   "config": {
     "sort-packages": true,
     "allow-plugins": {
-      "infection/extension-installer": true
+      "infection/extension-installer": true,
+      "pestphp/pest-plugin": true
     }
   },
   "extra": {

--- a/src/Support/GenericsLazyCollection.php
+++ b/src/Support/GenericsLazyCollection.php
@@ -26,7 +26,7 @@ class GenericsLazyCollection extends LazyTypedCollection
 
     protected function generics(): string|Type|array
     {
-        return $this->generics;
+        return $this->generics ?: [];
     }
 
     protected function keyGenerics(): string|Type|array

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+uses(Orchestra\Testbench\TestCase::class)->in('Unit');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+

--- a/tests/Stubs/TestObject.php
+++ b/tests/Stubs/TestObject.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Henzeb\Collection\Tests\Stubs;
+
+class TestObject
+{
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+}

--- a/tests/Unit/Concerns/TypedCollectionTest.php
+++ b/tests/Unit/Concerns/TypedCollectionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Concerns;
-
 use Henzeb\Collection\Concerns\TypedCollection;
 use Henzeb\Collection\EloquentTypedCollection;
 use Henzeb\Collection\Exceptions\InvalidTypedCollectionException;
@@ -13,84 +11,76 @@ use Henzeb\Collection\Typed\Strings;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\LazyCollection;
-use Orchestra\Testbench\TestCase;
 
-class TypedCollectionTest extends TestCase
+class TestTypedCollectionClass
 {
     use TypedCollection;
-
+    
     public $typedCollection = null;
-
-    public function testUserModelAllShouldReturnUsersCollection()
-    {
-        $collection = User::all();
-
-        $this->assertInstanceOf(Users::class, $collection);
-        $this->assertInstanceOf(EloquentTypedCollection::class, $collection);
-        $this->assertInstanceOf(Collection::class, $collection);
-
-        $this->assertCount(3, $collection);
-        $this->assertEquals(1, $collection->first()->id);
-        $this->assertEquals('Wally', $collection->get(1)->name);
-        $this->assertEquals('Allen-West', $collection->get(2)->last_name);
-    }
-
-
-    public function testShouldThrowErrorWhenInvalidCollectionType()
-    {
-        $this->typedCollection = self::class;
-        $this->expectException(InvalidTypedCollectionException::class);
-        $this->expectExceptionMessageMatches('/`TypedCollectionTest`/');
-
-        $this->newCollection();
-    }
-
-    public function testShouldThrowErrorWhenNotTypedCollection()
-    {
-        $this->typedCollection = BaseCollection::class;
-        $this->expectException(InvalidTypedCollectionException::class);
-        $this->expectExceptionMessageMatches('/`TypedCollectionTest`/');
-
-        $this->newCollection();
-    }
-
-    public function testShouldThrowErrorWhenNotEloquentTypedCollection()
-    {
-        $this->typedCollection = Collection::class;
-        $this->expectException(InvalidTypedCollectionException::class);
-        $this->expectExceptionMessageMatches('/`TypedCollectionTest`/');
-
-        $this->newCollection();
-    }
-
-    public function testShouldThrowErrorWhenTypedLazyCollection()
-    {
-        $this->typedCollection = LazyCollection::class;
-        $this->expectException(InvalidTypedCollectionException::class);
-        $this->expectExceptionMessageMatches('/`TypedCollectionTest`/');
-
-        $this->newCollection();
-    }
-
-    public function testShouldThrowErrorWhenTypedCollectionOmitted()
-    {
-        $this->expectException(MissingTypedCollectionException::class);
-        $this->expectExceptionMessageMatches('/`TypedCollectionTest`/');
-
-        $this->newCollection();
-    }
-
-    public function testShouldReturnTypedCollection()
-    {
-        $this->typedCollection = Strings::class;
-
-        $this->assertInstanceOf(Strings::class, $this->newCollection());
-    }
-
-    public function testShouldReturnLazyTypedCollection()
-    {
-        $this->typedCollection = Integers::class;
-
-        $this->assertInstanceOf(Integers::class, $this->newCollection());
-    }
 }
+
+test('user model all should return users collection', function () {
+    $collection = User::all();
+
+    expect($collection)->toBeInstanceOf(Users::class);
+    expect($collection)->toBeInstanceOf(EloquentTypedCollection::class);
+    expect($collection)->toBeInstanceOf(Collection::class);
+
+    expect($collection)->toHaveCount(3);
+    expect($collection->first()->id)->toBe(1);
+    expect($collection->get(1)->name)->toBe('Wally');
+    expect($collection->get(2)->last_name)->toBe('Allen-West');
+});
+
+test('should throw error when invalid collection type', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = TestTypedCollectionClass::class;
+    
+    expect(fn() => $testClass->newCollection())
+        ->toThrow(InvalidTypedCollectionException::class, 'TestTypedCollectionClass');
+});
+
+test('should throw error when not typed collection', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = BaseCollection::class;
+    
+    expect(fn() => $testClass->newCollection())
+        ->toThrow(InvalidTypedCollectionException::class, 'TestTypedCollectionClass');
+});
+
+test('should throw error when not eloquent typed collection', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = Collection::class;
+    
+    expect(fn() => $testClass->newCollection())
+        ->toThrow(InvalidTypedCollectionException::class, 'TestTypedCollectionClass');
+});
+
+test('should throw error when typed lazy collection', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = LazyCollection::class;
+    
+    expect(fn() => $testClass->newCollection())
+        ->toThrow(InvalidTypedCollectionException::class, 'TestTypedCollectionClass');
+});
+
+test('should throw error when typed collection omitted', function () {
+    $testClass = new TestTypedCollectionClass();
+    
+    expect(fn() => $testClass->newCollection())
+        ->toThrow(MissingTypedCollectionException::class, 'TestTypedCollectionClass');
+});
+
+test('should return typed collection', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = Strings::class;
+
+    expect($testClass->newCollection())->toBeInstanceOf(Strings::class);
+});
+
+test('should return lazy typed collection', function () {
+    $testClass = new TestTypedCollectionClass();
+    $testClass->typedCollection = Integers::class;
+
+    expect($testClass->newCollection())->toBeInstanceOf(Integers::class);
+});

--- a/tests/Unit/Enums/TypeTest.php
+++ b/tests/Unit/Enums/TypeTest.php
@@ -1,122 +1,65 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Enums;
-
 use Henzeb\Collection\Enums\Type;
-use PHPUnit\Framework\TestCase;
-use stdClass;
 
-class TypeTest extends TestCase
+function getTryFromTestcases(): array
 {
-    public static function providesTryFromTestcases(): array
-    {
-        $result = [
-            'invalid' => [null, 'failure']
-        ];
+    $result = [
+        'invalid' => [null, 'failure']
+    ];
 
-        foreach (Type::cases() as $case) {
-            $name = strtolower($case->name);
-            $result[$name] = [$case, $case->name];
-            $result[$name . '-upper'] = [$case, strtoupper($case->name)];
-            $result[$name . '-lower'] = [$case, $name];
-        }
-
-        return $result;
+    foreach (Type::cases() as $case) {
+        $name = strtolower($case->name);
+        $result[$name] = [$case, $case->name];
+        $result[$name . '-upper'] = [$case, strtoupper($case->name)];
+        $result[$name . '-lower'] = [$case, $name];
     }
 
-    /**
-     * @param Type|null $expects
-     * @param $tryFrom
-     * @return void
-     *
-     * @dataProvider providesTryFromTestcases
-     */
-    public function testTryFrom(?Type $expects, $tryFrom)
-    {
-        $this->assertEquals($expects, Type::tryFrom($tryFrom));
-    }
-
-    public static function providesFromValueTestcases(): array
-    {
-        return [
-            'bool' => [Type::Bool, true],
-            'string' => [Type::String, 'Hello World'],
-            'numeric' => [Type::Numeric, '1.0'],
-            'integer' => [Type::Int, 1],
-            'double' => [Type::Double, 1.1],
-            'array' => [Type::Array, ['Array']],
-            'null' => [Type::Null, null],
-            'resource' => [Type::Resource, fopen('php://memory', 'r+')],
-            'closed-resource' => [null, tap(fopen('php://memory', 'r+'), fn($stdin) => fclose($stdin))],
-            'object' => [Type::Object, new stdClass()],
-        ];
-    }
-
-    /**
-     * @param Type $expects
-     * @param mixed $from
-     * @return void
-     *
-     * @dataProvider providesFromValueTestcases
-     */
-    public function testFromValue(?Type $expects, mixed $from)
-    {
-        $this->assertEquals(
-            $expects,
-            Type::fromValue($from)
-        );
-    }
-
-    public static function providesEqualsTestcases(): array
-    {
-        return [
-            [null, Type::String, false],
-            [Type::Int, Type::String, false],
-            [Type::String, Type::String, true],
-            [Type::Int, Type::Numeric, true], // an integer is a numeric
-            [Type::Double, Type::Numeric, true], // a double is a numeric,
-            [Type::Numeric, Type::Numeric, true], // a numeric is a numeric,
-            [Type::Numeric, Type::Int, false], // a numeric value is not per sé an integer
-            [Type::Numeric, Type::Double, false], // a numeric value is not per sé a double
-        ];
-    }
-
-    /**
-     * @param Type|null $match
-     * @param Type $with
-     * @param bool $expected
-     * @return void
-     *
-     * @dataProvider providesEqualsTestcases
-     */
-    public function testEquals(Type|null $match, Type $with, bool $expected)
-    {
-        $this->assertEquals($expected, $with->equals($match));
-    }
-
-    public static function providesValueTestcases()
-    {
-        return [
-            ['type' => Type::Bool, 'expected' => 'boolean'],
-            ['type' => Type::String, 'expected' => 'string'],
-            ['type' => Type::Int, 'expected' => 'integer'],
-            ['type' => Type::Double, 'expected' => 'double'],
-            ['type' => Type::Array, 'expected' => 'array'],
-            ['type' => Type::Null, 'expected' => 'NULL'],
-            ['type' => Type::Resource, 'expected' => 'resource'],
-            ['type' => Type::Object, 'expected' => 'object'],
-            ['type' => Type::Numeric, 'expected' => 'numeric']
-        ];
-    }
-
-    /**
-     * @param Type $type
-     * @param string $expected
-     * @return void
-     * @dataProvider providesValueTestcases
-     */
-    public function testValue(Type $type, string $expected): void
-    {
-        $this->assertEquals($expected, $type->value());
-    }
+    return $result;
 }
+
+test('try from', function (?Type $expects, $tryFrom) {
+    expect(Type::tryFrom($tryFrom))->toBe($expects);
+})->with(getTryFromTestcases());
+
+test('from value', function (?Type $expects, mixed $from) {
+    expect(Type::fromValue($from))->toBe($expects);
+})->with([
+    'bool' => [Type::Bool, true],
+    'string' => [Type::String, 'Hello World'],
+    'numeric' => [Type::Numeric, '1.0'],
+    'integer' => [Type::Int, 1],
+    'double' => [Type::Double, 1.1],
+    'array' => [Type::Array, ['Array']],
+    'null' => [Type::Null, null],
+    'resource' => [Type::Resource, fopen('php://memory', 'r+')],
+    'closed-resource' => [null, tap(fopen('php://memory', 'r+'), fn($stdin) => fclose($stdin))],
+    'object' => [Type::Object, new \stdClass()],
+]);
+
+test('equals', function (Type|null $match, Type $with, bool $expected) {
+    expect($with->equals($match))->toBe($expected);
+})->with([
+    [null, Type::String, false],
+    [Type::Int, Type::String, false],
+    [Type::String, Type::String, true],
+    [Type::Int, Type::Numeric, true],
+    [Type::Double, Type::Numeric, true],
+    [Type::Numeric, Type::Numeric, true],
+    [Type::Numeric, Type::Int, false],
+    [Type::Numeric, Type::Double, false],
+]);
+
+test('value', function (Type $type, string $expected) {
+    expect($type->value())->toBe($expected);
+})->with([
+    [Type::Bool, 'boolean'],
+    [Type::String, 'string'],
+    [Type::Int, 'integer'],
+    [Type::Double, 'double'],
+    [Type::Array, 'array'],
+    [Type::Null, 'NULL'],
+    [Type::Resource, 'resource'],
+    [Type::Object, 'object'],
+    [Type::Numeric, 'numeric']
+]);

--- a/tests/Unit/Exceptions/InvalidGenericExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidGenericExceptionTest.php
@@ -1,24 +1,11 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\InvalidGenericException;
-use PHPUnit\Framework\TestCase;
 
-class InvalidGenericExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new InvalidGenericException('hello world');
-        $this->assertSame(
-            'The specified generic type `hello world` is invalid or not supported.',
-            $exception->getMessage()
-        );
+test('message contains generic', function () {
+    $exception = new InvalidGenericException('hello world');
+    expect($exception->getMessage())->toBe('The specified generic type `hello world` is invalid or not supported.');
 
-        $exception = new InvalidGenericException('another planet');
-        $this->assertSame(
-            'The specified generic type `another planet` is invalid or not supported.',
-            $exception->getMessage()
-        );
-    }
-}
+    $exception = new InvalidGenericException('another planet');
+    expect($exception->getMessage())->toBe('The specified generic type `another planet` is invalid or not supported.');
+});

--- a/tests/Unit/Exceptions/InvalidKeyGenericExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidKeyGenericExceptionTest.php
@@ -1,31 +1,14 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\InvalidKeyGenericException;
-use PHPUnit\Framework\TestCase;
-use stdClass;
 
-class InvalidKeyGenericExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new InvalidKeyGenericException('hello world');
-        $this->assertSame(
-            'Type of `hello world` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.',
-            $exception->getMessage()
-        );
+test('message contains generic', function () {
+    $exception = new InvalidKeyGenericException('hello world');
+    expect($exception->getMessage())->toBe('Type of `hello world` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.');
 
-        $exception = new InvalidKeyGenericException(new stdClass());
-        $this->assertSame(
-            'Type of `unknown` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.',
-            $exception->getMessage()
-        );
+    $exception = new InvalidKeyGenericException(new \stdClass());
+    expect($exception->getMessage())->toBe('Type of `unknown` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.');
 
-        $exception = new InvalidKeyGenericException(stdClass::class);
-        $this->assertSame(
-            'Type of `stdClass` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.',
-            $exception->getMessage()
-        );
-    }
-}
+    $exception = new InvalidKeyGenericException(\stdClass::class);
+    expect($exception->getMessage())->toBe('Type of `stdClass` is invalid. Expected one of [integer, numeric, string, boolean, NULL] or custom generic type.');
+});

--- a/tests/Unit/Exceptions/InvalidKeyTypeExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidKeyTypeExceptionTest.php
@@ -1,33 +1,16 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Enums\Type;
 use Henzeb\Collection\Exceptions\InvalidKeyTypeException;
 use Henzeb\Collection\Generics\Uuid;
-use PHPUnit\Framework\TestCase;
-use stdClass;
 
-class InvalidKeyTypeExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new InvalidKeyTypeException(self::class, 'hello world', [Type::Bool, Uuid::class]);
-        $this->assertSame(
-            self::class . ': The given key `string` does not match (one of) the generic types [boolean, Henzeb\Collection\Generics\Uuid] for this collection.',
-            $exception->getMessage()
-        );
+test('message contains generic', function () {
+    $exception = new InvalidKeyTypeException('InvalidKeyTypeExceptionTest', 'hello world', [Type::Bool, Uuid::class]);
+    expect($exception->getMessage())->toBe('InvalidKeyTypeExceptionTest: The given key `string` does not match (one of) the generic types [boolean, Henzeb\Collection\Generics\Uuid] for this collection.');
 
-        $exception = new InvalidKeyTypeException(self::class, new stdClass(), [Type::String]);
-        $this->assertSame(
-            self::class . ': The given key `stdClass` does not match (one of) the generic types [string] for this collection.',
-            $exception->getMessage()
-        );
+    $exception = new InvalidKeyTypeException('InvalidKeyTypeExceptionTest', new \stdClass(), [Type::String]);
+    expect($exception->getMessage())->toBe('InvalidKeyTypeExceptionTest: The given key `stdClass` does not match (one of) the generic types [string] for this collection.');
 
-        $exception = new InvalidKeyTypeException(stdClass::class, stdClass::class, [Type::Int]);
-        $this->assertSame(
-            'stdClass: The given key `string` does not match (one of) the generic types [integer] for this collection.',
-            $exception->getMessage()
-        );
-    }
-}
+    $exception = new InvalidKeyTypeException(\stdClass::class, \stdClass::class, [Type::Int]);
+    expect($exception->getMessage())->toBe('stdClass: The given key `string` does not match (one of) the generic types [integer] for this collection.');
+});

--- a/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidTypeExceptionTest.php
@@ -1,68 +1,48 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Enums\Type;
 use Henzeb\Collection\Exceptions\InvalidTypeException;
-use PHPUnit\Framework\TestCase;
 
-class InvalidTypeExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new InvalidTypeException(
-            self::class,
-            'Hello World',
-            [self::class, Type::Numeric]
-        );
-        $this->assertSame(
-            'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest: The given value `string` does not match (one of) the generic type [Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest, numeric] for this collection.',
-            $exception->getMessage()
-        );
-    }
+test('message contains generic', function () {
+    $exception = new InvalidTypeException(
+        'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest',
+        'Hello World',
+        ['Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest', Type::Numeric]
+    );
+    expect($exception->getMessage())->toBe(
+        'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest: The given value `string` does not match (one of) the generic type [Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest, numeric] for this collection.'
+    );
+});
 
-    public function testMessageContainsUnknownGeneric()
-    {
-        $exception = new InvalidTypeException(
-            self::class,
-            'Hello World',
-            [$this]
-        );
-        $this->assertSame(
-            'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest: The given value `string` does not match (one of) the generic type [unknown] for this collection.',
-            $exception->getMessage()
-        );
-    }
+test('message contains unknown generic', function () {
+    $testObject = new class {};
+    $exception = new InvalidTypeException(
+        'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest',
+        'Hello World',
+        [$testObject]
+    );
+    expect($exception->getMessage())->toBe(
+        'Henzeb\Collection\Tests\Unit\Exceptions\InvalidTypeExceptionTest: The given value `string` does not match (one of) the generic type [unknown] for this collection.'
+    );
+});
 
-    public static function providesTypeTestcases()
-    {
-        return [
-            'string' => ['Hello World', 'string'],
-            'numeric' => ['21', 'numeric'],
-            'resource' => [STDIN, 'resource'],
-            'double' => [1.1, 'double'],
-            'array' => [['hello'], 'array'],
-            'boolean' => [true, 'boolean'],
-            'integer' => [21, 'integer'],
-        ];
-    }
 
-    /**
-     * @return void
-     *
-     * @dataProvider providesTypeTestcases
-     */
-    public function testMessageContainsGenericTypeOfItem(mixed $item, string $expectedValue)
-    {
-        $exception = new InvalidTypeException(
-            'test',
-            $item,
-            []
-        );
+test('message contains generic type of item', function (mixed $item, string $expectedValue) {
+    $exception = new InvalidTypeException(
+        'test',
+        $item,
+        []
+    );
 
-        $this->assertSame(
-            'test: The given value `' . $expectedValue . '` does not match (one of) the generic type [] for this collection.',
-            $exception->getMessage()
-        );
-    }
-}
+    expect($exception->getMessage())->toBe(
+        'test: The given value `' . $expectedValue . '` does not match (one of) the generic type [] for this collection.'
+    );
+})->with([
+    'string' => ['Hello World', 'string'],
+    'numeric' => ['21', 'numeric'],
+    'resource' => [STDIN, 'resource'],
+    'double' => [1.1, 'double'],
+    'array' => [['hello'], 'array'],
+    'boolean' => [true, 'boolean'],
+    'integer' => [21, 'integer'],
+]);

--- a/tests/Unit/Exceptions/InvalidTypedCollectionExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidTypedCollectionExceptionTest.php
@@ -1,24 +1,11 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\InvalidTypedCollectionException;
-use PHPUnit\Framework\TestCase;
 
-class InvalidTypedCollectionExceptionTest extends TestCase
-{
-    public function testMessage()
-    {
-        $exception = new InvalidTypedCollectionException(self::class);
-        $this->assertSame(
-            'Invalid typed collection for `InvalidTypedCollectionExceptionTest`. Specify a typed collection in $typedCollection, or remove trait.',
-            $exception->getMessage()
-        );
+test('message', function () {
+    $exception = new InvalidTypedCollectionException('InvalidTypedCollectionExceptionTest');
+    expect($exception->getMessage())->toBe('Invalid typed collection for `InvalidTypedCollectionExceptionTest`. Specify a typed collection in $typedCollection, or remove trait.');
 
-        $exception = new InvalidTypedCollectionException('hello world');
-        $this->assertSame(
-            'Invalid typed collection for `hello world`. Specify a typed collection in $typedCollection, or remove trait.',
-            $exception->getMessage()
-        );
-    }
-}
+    $exception = new InvalidTypedCollectionException('hello world');
+    expect($exception->getMessage())->toBe('Invalid typed collection for `hello world`. Specify a typed collection in $typedCollection, or remove trait.');
+});

--- a/tests/Unit/Exceptions/MissingGenericsExceptionTest.php
+++ b/tests/Unit/Exceptions/MissingGenericsExceptionTest.php
@@ -1,18 +1,8 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\MissingGenericsException;
-use PHPUnit\Framework\TestCase;
 
-class MissingGenericsExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new MissingGenericsException();
-        $this->assertSame(
-            'At least one generic type must be specified.',
-            $exception->getMessage()
-        );
-    }
-}
+test('message contains generic', function () {
+    $exception = new MissingGenericsException();
+    expect($exception->getMessage())->toBe('At least one generic type must be specified.');
+});

--- a/tests/Unit/Exceptions/MissingKeyGenericsExceptionTest.php
+++ b/tests/Unit/Exceptions/MissingKeyGenericsExceptionTest.php
@@ -1,18 +1,8 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\MissingKeyGenericsException;
-use PHPUnit\Framework\TestCase;
 
-class MissingKeyGenericsExceptionTest extends TestCase
-{
-    public function testMessageContainsGeneric()
-    {
-        $exception = new MissingKeyGenericsException();
-        $this->assertSame(
-            'At least one generic key type must be specified.',
-            $exception->getMessage()
-        );
-    }
-}
+test('message contains generic', function () {
+    $exception = new MissingKeyGenericsException();
+    expect($exception->getMessage())->toBe('At least one generic key type must be specified.');
+});

--- a/tests/Unit/Exceptions/MissingTypedCollectionExceptionTest.php
+++ b/tests/Unit/Exceptions/MissingTypedCollectionExceptionTest.php
@@ -1,24 +1,11 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Exceptions;
-
 use Henzeb\Collection\Exceptions\MissingTypedCollectionException;
-use PHPUnit\Framework\TestCase;
 
-class MissingTypedCollectionExceptionTest extends TestCase
-{
-    public function testMessage()
-    {
-        $exception = new MissingTypedCollectionException(self::class);
-        $this->assertSame(
-            'Missing typed collection for `MissingTypedCollectionExceptionTest`. Specify one in $typedCollection, or remove trait.',
-            $exception->getMessage()
-        );
+test('message', function () {
+    $exception = new MissingTypedCollectionException('MissingTypedCollectionExceptionTest');
+    expect($exception->getMessage())->toBe('Missing typed collection for `MissingTypedCollectionExceptionTest`. Specify one in $typedCollection, or remove trait.');
 
-        $exception = new MissingTypedCollectionException('another planet');
-        $this->assertSame(
-            'Missing typed collection for `another planet`. Specify one in $typedCollection, or remove trait.',
-            $exception->getMessage()
-        );
-    }
-}
+    $exception = new MissingTypedCollectionException('another planet');
+    expect($exception->getMessage())->toBe('Missing typed collection for `another planet`. Specify one in $typedCollection, or remove trait.');
+});

--- a/tests/Unit/Generics/JsonTest.php
+++ b/tests/Unit/Generics/JsonTest.php
@@ -1,189 +1,139 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Generics;
-
-use Closure;
-use Generator;
 use Henzeb\Collection\Generics\Json;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use JsonSerializable;
-use PHPUnit\Framework\TestCase;
-use Throwable;
 
-class JsonTest extends TestCase
+function useNative(?bool $useJsonValidate)
 {
-    public function testMemoization()
-    {
-        $useValidate = !function_exists('json_validate'); // false
-        $this->useNative($useValidate); // set to false
-
-        try {
-            Json::matchesType(json_encode([]));
-        } catch (Throwable) {
-        }
-
-        $this->assertNativeSet($useValidate);
-
-    }
-
-    public function testJsonValidates(): void
-    {
-        $this->useNative(false);
-
-        $this->assertTrue(
-            Json::matchesType(
-                json_encode(['hello' => 'world'])
-            )
-        );
-    }
-
-    public function testJsonValidatesNative(): void
-    {
-        $this->assertTrue(
-            Json::matchesType(
-                json_encode(['hello' => 'world'])
-            )
-        );
-    }
-
-    public function testJsonValidatesDepth(): void
-    {
-        $this->useNative(false);
-        $this->assertTrue(
-            Json::matchesType(
-                json_encode(
-                    $this->generateArray(512)
-                )
-            )
-        );
-
-        $this->assertFalse(
-            Json::matchesType(
-                json_encode(
-                    $this->generateArray(513)
-                )
-            )
-        );
-    }
-
-    function generateArray($depth)
-    {
-        if ($depth === 0) {
-            return [];
-        }
-        $array = 1;
-        for ($i = $depth; $i > 1; $i--) {
-            $array = [$array];
-        }
-
-        return $array;
-    }
-
-    public function testJsonFailsOnNonString(): void
-    {
-        $this->useNative(false);
-
-        $this->assertFalse(Json::matchesType(['hello' => 'world']));
-    }
-
-    public function testJsonFailsOnNonStringNative(): void
-    {
-        $this->assertFalse(Json::matchesType(['hello' => 'world']));
-    }
-
-    public function testJsonFailsOnNotAJsonString(): void
-    {
-        $this->useNative(false);
-
-        $this->assertFalse(Json::matchesType('Not a Json'));
-    }
-
-    public function testJsonFailsOnNotAJsonNative(): void
-    {
-        $this->assertFalse(Json::matchesType('Not a Json'));
-    }
-
-    public function testJsonFailsOnInvalidJson(): void
-    {
-        $this->useNative(false);
-        $this->assertFalse(
-            Json::matchesType(
-                ltrim(json_encode(['hello' => 'world']), '{')
-            )
-        );
-    }
-
-    public function testJsonFailsOnInvalidJsonNative(): void
-    {
-        $this->assertFalse(
-            Json::matchesType(
-                ltrim(json_encode(['hello' => 'world']), '{')
-            )
-        );
-    }
-
-    public function testTypecast()
-    {
-        $expected = json_encode(['regular' => 'array']);
-        $this->assertEquals($expected, Json::castType(['regular' => 'array']));
-        $this->assertEquals($expected, Json::castType(collect(['regular' => 'array'])));
-
-        $this->assertEquals($expected, Json::castType(
-            new class implements Arrayable {
-                public function toArray()
-                {
-                    return ['regular' => 'array'];
-                }
-            }
-        ));
-
-        $this->assertEquals($expected, Json::castType(
-            new class implements JsonSerializable {
-                public function jsonSerialize(): mixed
-                {
-                    return ['regular' => 'array'];
-                }
-            }
-        ));
-
-        $this->assertEquals($expected, Json::castType(
-            new class implements Jsonable {
-                public function toJson($options = 0): string
-                {
-                    return json_encode(['regular' => 'array']);
-                }
-            }
-        ));
-
-
-        $this->assertEquals($expected, Json::castType(
-            (function (): Generator {
-                yield 'regular' => 'array';
-            })()
-        ));
-    }
-
-    public function useNative(?bool $useJsonValidate)
-    {
-        Closure::bind(function (?bool $useNative) {
-            self::$useJsonValidate = $useNative;
-        }, null, Json::class)(
-            $useJsonValidate
-        );
-    }
-
-    public function assertNativeSet(bool $expected): void
-    {
-        $native = Closure::bind(function () {
-            return self::$useJsonValidate;
-        }, null, Json::class)();
-
-        $this->assertEquals($expected, $native);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->useNative(null);
-    }
+    \Closure::bind(function (?bool $useNative) {
+        self::$useJsonValidate = $useNative;
+    }, null, Json::class)(
+        $useJsonValidate
+    );
 }
+
+function assertNativeSet(bool $expected): void
+{
+    $native = \Closure::bind(function () {
+        return self::$useJsonValidate;
+    }, null, Json::class)();
+
+    expect($native)->toBe($expected);
+}
+
+function generateArray($depth)
+{
+    if ($depth === 0) {
+        return [];
+    }
+    $array = 1;
+    for ($i = $depth; $i > 1; $i--) {
+        $array = [$array];
+    }
+
+    return $array;
+}
+
+afterEach(function () {
+    useNative(null);
+});
+
+test('memoization', function () {
+    $useValidate = !function_exists('json_validate');
+    useNative($useValidate);
+
+    try {
+        Json::matchesType(json_encode([]));
+    } catch (\Throwable) {
+    }
+
+    assertNativeSet($useValidate);
+});
+
+test('json validates', function () {
+    useNative(false);
+
+    expect(Json::matchesType(json_encode(['hello' => 'world'])))->toBeTrue();
+});
+
+test('json validates native', function () {
+    expect(Json::matchesType(json_encode(['hello' => 'world'])))->toBeTrue();
+});
+
+test('json validates depth', function () {
+    useNative(false);
+    
+    expect(Json::matchesType(json_encode(generateArray(512))))->toBeTrue();
+    expect(Json::matchesType(json_encode(generateArray(513))))->toBeFalse();
+});
+
+test('json fails on non string', function () {
+    useNative(false);
+
+    expect(Json::matchesType(['hello' => 'world']))->toBeFalse();
+});
+
+test('json fails on non string native', function () {
+    expect(Json::matchesType(['hello' => 'world']))->toBeFalse();
+});
+
+test('json fails on not a json string', function () {
+    useNative(false);
+
+    expect(Json::matchesType('Not a Json'))->toBeFalse();
+});
+
+test('json fails on not a json native', function () {
+    expect(Json::matchesType('Not a Json'))->toBeFalse();
+});
+
+test('json fails on invalid json', function () {
+    useNative(false);
+    
+    expect(Json::matchesType(ltrim(json_encode(['hello' => 'world']), '{')))->toBeFalse();
+});
+
+test('json fails on invalid json native', function () {
+    expect(Json::matchesType(ltrim(json_encode(['hello' => 'world']), '{')))->toBeFalse();
+});
+
+test('typecast', function () {
+    $expected = json_encode(['regular' => 'array']);
+    
+    expect(Json::castType(['regular' => 'array']))->toBe($expected);
+    expect(Json::castType(collect(['regular' => 'array'])))->toBe($expected);
+
+    expect(Json::castType(
+        new class implements Arrayable {
+            public function toArray()
+            {
+                return ['regular' => 'array'];
+            }
+        }
+    ))->toBe($expected);
+
+    expect(Json::castType(
+        new class implements \JsonSerializable {
+            public function jsonSerialize(): mixed
+            {
+                return ['regular' => 'array'];
+            }
+        }
+    ))->toBe($expected);
+
+    expect(Json::castType(
+        new class implements Jsonable {
+            public function toJson($options = 0): string
+            {
+                return json_encode(['regular' => 'array']);
+            }
+        }
+    ))->toBe($expected);
+
+    expect(Json::castType(
+        (function (): \Generator {
+            yield 'regular' => 'array';
+        })()
+    ))->toBe($expected);
+});

--- a/tests/Unit/Generics/UlidTest.php
+++ b/tests/Unit/Generics/UlidTest.php
@@ -1,41 +1,19 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Generics;
-
 use Henzeb\Collection\Generics\Ulid;
-use PHPUnit\Framework\TestCase;
 
-class UlidTest extends TestCase
-{
-    public function testUlidValidates(): void
-    {
-        $this->assertTrue(
-            Ulid::matchesType(
-                '01H3EJ0BZ590C9N423E96YS2NS'
-            )
-        );
-    }
+test('ulid validates', function () {
+    expect(Ulid::matchesType('01H3EJ0BZ590C9N423E96YS2NS'))->toBeTrue();
+});
 
-    public function testFailsOnNonString(): void
-    {
-        $this->assertFalse(
-            Ulid::matchesType(
-                $this
-            )
-        );
-    }
+test('fails on non string', function () {
+    expect(Ulid::matchesType($this))->toBeFalse();
+});
 
-    public function testFailsOnNotUlidString(): void
-    {
-        $this->assertFalse(Ulid::matchesType('Not a Uuid'));
-    }
+test('fails on not ulid string', function () {
+    expect(Ulid::matchesType('Not a Uuid'))->toBeFalse();
+});
 
-    public function testFailsOnInvalidUlid(): void
-    {
-        $this->assertFalse(
-            Ulid::matchesType(
-                '01H3EJ0BZ590C9N423E96YS2N'
-            )
-        );
-    }
-}
+test('fails on invalid ulid', function () {
+    expect(Ulid::matchesType('01H3EJ0BZ590C9N423E96YS2N'))->toBeFalse();
+});

--- a/tests/Unit/Generics/UuidTest.php
+++ b/tests/Unit/Generics/UuidTest.php
@@ -1,41 +1,19 @@
 <?php
 
-namespace Henzeb\Collection\Tests\Unit\Generics;
-
 use Henzeb\Collection\Generics\Uuid;
-use PHPUnit\Framework\TestCase;
 
-class UuidTest extends TestCase
-{
-    public function testUuidValidates(): void
-    {
-        $this->assertTrue(
-            Uuid::matchesType(
-                '1b2a5269-de6f-4e19-a75a-06c0262dbcd7'
-            )
-        );
-    }
+test('uuid validates', function () {
+    expect(Uuid::matchesType('1b2a5269-de6f-4e19-a75a-06c0262dbcd7'))->toBeTrue();
+});
 
-    public function testFailsOnNonString(): void
-    {
-        $this->assertFalse(
-            Uuid::matchesType(
-                $this
-            )
-        );
-    }
+test('fails on non string', function () {
+    expect(Uuid::matchesType($this))->toBeFalse();
+});
 
-    public function testFailsOnNotUuidString(): void
-    {
-        $this->assertFalse(Uuid::matchesType('Not a Uuid'));
-    }
+test('fails on not uuid string', function () {
+    expect(Uuid::matchesType('Not a Uuid'))->toBeFalse();
+});
 
-    public function testFailsOnInvalidUuid(): void
-    {
-        $this->assertFalse(
-            Uuid::matchesType(
-                '1b2a5269-de6f-4e19-a75a-06c0262dbcd'
-            )
-        );
-    }
-}
+test('fails on invalid uuid', function () {
+    expect(Uuid::matchesType('1b2a5269-de6f-4e19-a75a-06c0262dbcd'))->toBeFalse();
+});

--- a/tests/Unit/Typed/ArraysTest.php
+++ b/tests/Unit/Typed/ArraysTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Arrays as LazyArrays;
+use Henzeb\Collection\Typed\Arrays;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Arrays {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Array);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Arrays {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyArrays::class);
+});
+
+it('lazy method returns lazy arrays instance', function () {
+    $collection = new Arrays([['a'], ['b']]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyArrays::class);
+});
+
+it('accepts array values', function () {
+    $collection = new Arrays([['a'], ['b', 'c']]);
+
+    expect($collection->toArray())->toBe([['a'], ['b', 'c']]);
+});
+
+it('rejects non-array values', function () {
+    expect(fn() => new Arrays(['string', 123]))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/BooleansTest.php
+++ b/tests/Unit/Typed/BooleansTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Booleans as LazyBooleans;
+use Henzeb\Collection\Typed\Booleans;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Booleans {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Bool);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Booleans {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyBooleans::class);
+});
+
+it('lazy method returns lazy booleans instance', function () {
+    $collection = new Booleans([true, false]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyBooleans::class);
+});
+
+it('accepts boolean values', function () {
+    $collection = new Booleans([true, false, true]);
+
+    expect($collection->toArray())->toBe([true, false, true]);
+});
+
+it('rejects non-boolean values', function () {
+    expect(fn() => new Booleans([true, 'string']))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/DoublesTest.php
+++ b/tests/Unit/Typed/DoublesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Doubles as LazyDoubles;
+use Henzeb\Collection\Typed\Doubles;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Doubles {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Double);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Doubles {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyDoubles::class);
+});
+
+it('lazy method returns lazy doubles instance', function () {
+    $collection = new Doubles([1.5, 2.7, 3.14]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyDoubles::class);
+});
+
+it('accepts double values', function () {
+    $collection = new Doubles([1.5, 2.7, 3.14]);
+
+    expect($collection->toArray())->toBe([1.5, 2.7, 3.14]);
+});
+
+it('rejects non-double values', function () {
+    expect(fn() => new Doubles([1.5, 'string']))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/IntegersTest.php
+++ b/tests/Unit/Typed/IntegersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Integers as LazyIntegers;
+use Henzeb\Collection\Typed\Integers;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Integers {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Int);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Integers {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyIntegers::class);
+});
+
+it('lazy method returns lazy integers instance', function () {
+    $collection = new Integers([1, 2, 3]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyIntegers::class);
+});
+
+it('accepts integer values', function () {
+    $collection = new Integers([1, 2, 3]);
+
+    expect($collection->toArray())->toBe([1, 2, 3]);
+});
+
+it('rejects non-integer values', function () {
+    expect(fn() => new Integers([1, 'string']))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/JsonsTest.php
+++ b/tests/Unit/Typed/JsonsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Generics\Json;
+use Henzeb\Collection\Lazy\Jsons as LazyJsons;
+use Henzeb\Collection\Typed\Jsons;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Jsons {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Json::class);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Jsons {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyJsons::class);
+});
+
+it('lazy method returns lazy jsons instance', function () {
+    $collection = new Jsons(['{"key": "value"}', '{"foo": "bar"}']);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyJsons::class);
+});
+
+it('accepts valid json values', function () {
+    $json1 = '{"key": "value"}';
+    $json2 = '{"foo": "bar"}';
+    $collection = new Jsons([$json1, $json2]);
+
+    expect($collection->toArray())->toBe([$json1, $json2]);
+});
+
+it('rejects invalid json values', function () {
+    expect(fn() => new Jsons(['{"valid": "json"}', 'invalid-json']))
+        ->toThrow(InvalidTypeException::class);
+});
+
+it('rejects non-string values', function () {
+    expect(fn() => new Jsons(['{"valid": "json"}', 123]))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/NumericsTest.php
+++ b/tests/Unit/Typed/NumericsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Numerics as LazyNumerics;
+use Henzeb\Collection\Typed\Numerics;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Numerics {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Numeric);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Numerics {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyNumerics::class);
+});
+
+it('lazy method returns lazy numerics instance', function () {
+    $collection = new Numerics([1, 2.5, '3']);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyNumerics::class);
+});
+
+it('accepts numeric values', function () {
+    $collection = new Numerics([1, 2.5, '3', '4.7']);
+
+    expect($collection->toArray())->toBe([1, 2.5, '3', '4.7']);
+});
+
+it('rejects non-numeric values', function () {
+    expect(fn() => new Numerics([1, 'not-numeric']))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/ObjectsTest.php
+++ b/tests/Unit/Typed/ObjectsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Objects as LazyObjects;
+use Henzeb\Collection\Typed\Objects;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Objects {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Object);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Objects {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyObjects::class);
+});
+
+it('lazy method returns lazy objects instance', function () {
+    $obj1 = new stdClass();
+    $obj2 = new stdClass();
+    $collection = new Objects([$obj1, $obj2]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyObjects::class);
+});
+
+it('accepts object values', function () {
+    $obj1 = new stdClass();
+    $obj2 = new stdClass();
+    $collection = new Objects([$obj1, $obj2]);
+
+    expect($collection->toArray())->toBe([$obj1, $obj2]);
+});
+
+it('rejects non-object values', function () {
+    $obj = new stdClass();
+    expect(fn() => new Objects([$obj, 'string']))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/ResourcesTest.php
+++ b/tests/Unit/Typed/ResourcesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Resources as LazyResources;
+use Henzeb\Collection\Typed\Resources;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Resources {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::Resource);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Resources {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyResources::class);
+});
+
+it('lazy method returns lazy resources instance', function () {
+    $resource1 = fopen('php://memory', 'r');
+    $resource2 = fopen('php://memory', 'r');
+    $collection = new Resources([$resource1, $resource2]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyResources::class);
+    
+    fclose($resource1);
+    fclose($resource2);
+});
+
+it('accepts resource values', function () {
+    $resource1 = fopen('php://memory', 'r');
+    $resource2 = fopen('php://memory', 'r');
+    $collection = new Resources([$resource1, $resource2]);
+
+    expect($collection->toArray())->toBe([$resource1, $resource2]);
+    
+    fclose($resource1);
+    fclose($resource2);
+});
+
+it('rejects non-resource values', function () {
+    $resource = fopen('php://memory', 'r');
+    
+    expect(fn() => new Resources([$resource, 'string']))
+        ->toThrow(InvalidTypeException::class);
+        
+    fclose($resource);
+});

--- a/tests/Unit/Typed/StringsTest.php
+++ b/tests/Unit/Typed/StringsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Henzeb\Collection\Enums\Type;
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Lazy\Strings as LazyStrings;
+use Henzeb\Collection\Typed\Strings;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Strings {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Type::String);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Strings {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyStrings::class);
+});
+
+it('lazy method returns lazy strings instance', function () {
+    $collection = new Strings(['hello', 'world']);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyStrings::class);
+});
+
+it('accepts string values', function () {
+    $collection = new Strings(['hello', 'world']);
+
+    expect($collection->toArray())->toBe(['hello', 'world']);
+});
+
+it('rejects non-string values', function () {
+    expect(fn() => new Strings(['string', 123]))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/UlidsTest.php
+++ b/tests/Unit/Typed/UlidsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Generics\Ulid;
+use Henzeb\Collection\Lazy\Ulids as LazyUlids;
+use Henzeb\Collection\Typed\Ulids;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Ulids {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Ulid::class);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Ulids {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyUlids::class);
+});
+
+it('lazy method returns lazy ulids instance', function () {
+    $ulid1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    $ulid2 = '01BX5ZZKBKACTAV9WEVGEMMVRY';
+    $collection = new Ulids([$ulid1, $ulid2]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyUlids::class);
+});
+
+it('accepts valid ulid values', function () {
+    $ulid1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    $ulid2 = '01BX5ZZKBKACTAV9WEVGEMMVRY';
+    $collection = new Ulids([$ulid1, $ulid2]);
+
+    expect($collection->toArray())->toBe([$ulid1, $ulid2]);
+});
+
+it('rejects invalid ulid values', function () {
+    $validUlid = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    expect(fn() => new Ulids([$validUlid, 'invalid-ulid']))
+        ->toThrow(InvalidTypeException::class);
+});
+
+it('rejects non-string values', function () {
+    $validUlid = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    expect(fn() => new Ulids([$validUlid, 123]))
+        ->toThrow(InvalidTypeException::class);
+});

--- a/tests/Unit/Typed/UuidsTest.php
+++ b/tests/Unit/Typed/UuidsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Henzeb\Collection\Exceptions\InvalidTypeException;
+use Henzeb\Collection\Generics\Uuid;
+use Henzeb\Collection\Lazy\Uuids as LazyUuids;
+use Henzeb\Collection\Typed\Uuids;
+
+it('returns correct generic type', function () {
+    $collection = new class extends Uuids {
+        public function getGenerics()
+        {
+            return $this->generics();
+        }
+    };
+
+    expect($collection->getGenerics())->toBe(Uuid::class);
+});
+
+it('returns correct lazy class', function () {
+    $collection = new class extends Uuids {
+        public function getLazyClass()
+        {
+            return $this->lazyClass();
+        }
+    };
+
+    expect($collection->getLazyClass())->toBe(LazyUuids::class);
+});
+
+it('lazy method returns lazy uuids instance', function () {
+    $uuid1 = '550e8400-e29b-41d4-a716-446655440000';
+    $uuid2 = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    $collection = new Uuids([$uuid1, $uuid2]);
+    $lazy = $collection->lazy();
+
+    expect($lazy)->toBeInstanceOf(LazyUuids::class);
+});
+
+it('accepts valid uuid values', function () {
+    $uuid1 = '550e8400-e29b-41d4-a716-446655440000';
+    $uuid2 = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    $collection = new Uuids([$uuid1, $uuid2]);
+
+    expect($collection->toArray())->toBe([$uuid1, $uuid2]);
+});
+
+it('rejects invalid uuid values', function () {
+    $validUuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(fn() => new Uuids([$validUuid, 'invalid-uuid']))
+        ->toThrow(InvalidTypeException::class);
+});
+
+it('rejects non-string values', function () {
+    $validUuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(fn() => new Uuids([$validUuid, 123]))
+        ->toThrow(InvalidTypeException::class);
+});


### PR DESCRIPTION
## Key Changes:
  - Added Pest as a dependency in composer.json
  - Updated test scripts to use vendor/bin/pest instead of phpunit
  - Added tests/Pest.php configuration file
  - Converted all test classes to Pest test functions
  - Changed from PHPUnit's $this->assert*() syntax to Pest's expect() syntax
  - Added a minor bug fix in GenericsLazyCollection.php (returning empty array instead of null)

  ## Summary:
  This PR modernizes the testing framework from PHPUnit to Pest, providing a more readable and expressive testing syntax while maintaining all existing test coverage.